### PR TITLE
add albums collection caching

### DIFF
--- a/lib/fotki.js
+++ b/lib/fotki.js
@@ -201,7 +201,14 @@ var fotki = INHERIT({}, {
                         body: newData
                     }).then(function(result){
                         if(fotki.albums._collectionCache){
-                            fotki.albums._collectionCache.push(result);
+                            fotki.albums._collectionCache.some(function(album, i){
+                                if(album.id === result.id){
+                                    fotki.albums._collectionCache[i] = result;
+                                    return true;
+                                }else{
+                                    return false;
+                                }
+                            });
                         }
                         return result;
                     });


### PR DESCRIPTION
I have over 4300 albums in my project. Without caching I can't add any photo.
This version of caching works correctly only if you have only one app instance with exclusive access to user account.

Warning: fotki.albums.edit and fotki.albums.delete was not tested.
