### PR TITLE
Invalid token error handling

### DIFF
--- a/lib/fotki.js
+++ b/lib/fotki.js
@@ -127,6 +127,10 @@ var fotki = INHERIT({}, {
                 return deferred.reject(body);
             }
 
+            if ((body || '').indexOf('Invalid token') === 0) {
+                return deferred.reject(body.replace(/(?:\r\n|\r|\n)/g, ' '));
+            }
+
             try {
                 deferred.resolve(JSON.parse(body));
             } catch(err) {


### PR DESCRIPTION
Привет!

Сейчас ошибка oauth-токена возвращается текстом в body, аналогично "Not an image or unsupported image format" (только в две строки).
